### PR TITLE
Prevent HTTP headers being set more than once.

### DIFF
--- a/routeutils/wsgicomm.py
+++ b/routeutils/wsgicomm.py
@@ -19,7 +19,7 @@ any later version.
 
 import sys
 
-response_headers = [('Access-Control-Allow-Origin', '*'),
+response_headers_template = [('Access-Control-Allow-Origin', '*'),
                     ('Access-Control-Allow-Headers', 'Authorization'),
                     ('Access-Control-Expose-Headers', 'WWW-Authenticate')]
 
@@ -209,6 +209,7 @@ def redirect_page(url, start_response):
     :platform: Linux
 
     """
+    response_headers = response_headers_template.copy()
     response_headers.append(('Location', url))
     start_response('301 Moved Permanently', response_headers)
     return ''
@@ -220,6 +221,7 @@ def send_html_response(status, body, start_response):
     :platform: Linux
 
     """
+    response_headers = response_headers_template.copy()
     response_headers.extend([('Content-Type', 'text/html; charset=UTF-8'),
                         ('Content-Length', str(len(body)))])
     start_response(status, response_headers)
@@ -232,6 +234,7 @@ def send_xml_response(status, body, start_response):
     :platform: Linux
 
     """
+    response_headers = response_headers_template.copy()
     response_headers.extend([('Content-Type', 'text/xml; charset=UTF-8'),
                         ('Content-Length', str(len(body)))])
     start_response(status, response_headers)
@@ -244,6 +247,7 @@ def send_plain_response(status, body, start_response):
     :platform: Linux
 
     """
+    response_headers = response_headers_template.copy()
     response_headers.extend([('Content-Type', 'text/plain'),
                         ('Content-Length', str(len(body)))])
     start_response(status, response_headers)
@@ -256,6 +260,7 @@ def send_json_response(status, body, start_response):
     :platform: Linux
 
     """
+    response_headers = response_headers_template.copy()
     response_headers.extend([('Content-Type', 'application/json'),
                         ('Content-Length', str(len(body)))])
     start_response(status, response_headers)
@@ -268,6 +273,7 @@ def send_nobody_response(status, start_response):
     :platform: Linux
 
     """
+    response_headers = response_headers_template.copy()
     response_headers.append(('Content-Length', 0))
     start_response(status, response_headers)
     return []
@@ -279,6 +285,7 @@ def send_error_response(status, body, start_response):
     :platform: Linux
 
     """
+    response_headers = response_headers_template.copy()
     response_headers.append(('Content-Type', 'text/plain'))
     # print response_headers
     # print status
@@ -295,6 +302,7 @@ def send_file_response(status, body, start_response):
     :platform: Linux
 
     """
+    response_headers = response_headers_template.copy()
     response_headers.extend([('Content-Type', body.content_type),
                         ('Content-Length', str(body.size)),
                         ('Content-Disposition', 'attachment; filename=%s' %
@@ -320,6 +328,7 @@ def send_dynamicfile_response(status, body, start_response):
             # ACTUALLY data to send
 
             # Content-length cannot be set because the file size is unknown
+            response_headers = response_headers_template.copy()
             response_headers.extend([('Content-Type', body.content_type),
                                 ('Content-Disposition',
                                  'attachment; filename=%s' % (body.filename))])


### PR DESCRIPTION
Within `routeutils/wsgicomm.py` there is a global parameter that contains the HTTP headers. Every request any user makes another header is appended to this headers object e.g.:

    response_headers.append(('Location', url))

Meaning that the HTTP response will eventually have crazy headers. I guess some software strips headers that are specified multiple times and some other software goes bonkers.

    [orfeus@knmi-orweb-l02p routing-1.1.2-rc1]$ curl -v 0.0.0.0:9090/eidaws/routing/1/version
    * About to connect() to 0.0.0.0 port 9090 (#0)
    *   Trying 0.0.0.0...
    * Connected to 0.0.0.0 (0.0.0.0) port 9090 (#0)
    > GET /eidaws/routing/1/version HTTP/1.1
    > User-Agent: curl/7.29.0
    > Host: 0.0.0.0:9090
    > Accept: */*
    >
    < HTTP/1.1 200 OK
    < Access-Control-Allow-Origin: *
    < Access-Control-Allow-Headers: Authorization
    < Access-Control-Expose-Headers: WWW-Authenticate
    < Content-Type: text/xml; charset=UTF-8
    < Content-Type: text/plain
    < Content-Type: text/plain
    < Content-Type: text/plain
    < Content-Type: text/plain
    < Content-Type: text/plain
    < Content-Type: text/plain
    < Content-Type: text/plain
    < Content-Type: text/plain

I made the global definition a template and copy it for each response before modifying it. My routing service `1.1.2-rc` is using this change and is now working properly.. please check and confirm!